### PR TITLE
Deactivate Bitcoin Core hot wallets in Spectrum (for now)

### DIFF
--- a/src/cryptoadvance/specterext/spectrum/spectrum_node.py
+++ b/src/cryptoadvance/specterext/spectrum/spectrum_node.py
@@ -2,6 +2,7 @@ import logging
 from cryptoadvance.specterext.spectrum.bridge_rpc import BridgeRPC
 from cryptoadvance.specter.helpers import deep_update
 from cryptoadvance.specter.node import AbstractNode
+from cryptoadvance.specter.device import Device
 from cryptoadvance.specter.specter_error import BrokenCoreConnectionException
 from cryptoadvance.spectrum.spectrum import Spectrum
 
@@ -172,6 +173,13 @@ class SpectrumNode(AbstractNode):
     def update_rpc(self):
         ''' No need to do anything '''
         pass
+
+    def device_is_not_supported(self, device: Device):
+        """ Returns True if a device is not supported for Spectrum nodes
+        Currently, Bitcoin Core hot wallets are not supported """
+        if device.__class__.__name__ == "BitcoinCore":
+            return True
+        return False
 
     def node_info_template(self):
         return "spectrum/components/spectrum_info.jinja"

--- a/src/cryptoadvance/specterext/spectrum/spectrum_node.py
+++ b/src/cryptoadvance/specterext/spectrum/spectrum_node.py
@@ -3,6 +3,7 @@ from cryptoadvance.specterext.spectrum.bridge_rpc import BridgeRPC
 from cryptoadvance.specter.helpers import deep_update
 from cryptoadvance.specter.node import AbstractNode
 from cryptoadvance.specter.device import Device
+from cryptoadvance.specter.devices.bitcoin_core import BitcoinCore
 from cryptoadvance.specter.specter_error import BrokenCoreConnectionException
 from cryptoadvance.spectrum.spectrum import Spectrum
 
@@ -174,12 +175,17 @@ class SpectrumNode(AbstractNode):
         ''' No need to do anything '''
         pass
 
-    def device_is_not_supported(self, device: Device):
-        """ Returns True if a device is not supported for Spectrum nodes
+    def is_device_supported(self, device_class_or_device_instance):
+        """ Returns False if a device is not supported for Spectrum nodes, True otherwise.
         Currently, Bitcoin Core hot wallets are not supported """
-        if device.__class__.__name__ == "BitcoinCore":
-            return True
-        return False
+        # If a device class is passed as argument, take that, otherwise derive the class from the instance
+        if device_class_or_device_instance.__class__ == type:
+            device_class = device_class_or_device_instance
+        else:
+            device_class = device_class_or_device_instance.__class__
+        if device_class == BitcoinCore:
+           return False
+        return True
 
     def node_info_template(self):
         return "spectrum/components/spectrum_info.jinja"

--- a/src/cryptoadvance/specterext/spectrum/spectrum_node.py
+++ b/src/cryptoadvance/specterext/spectrum/spectrum_node.py
@@ -2,7 +2,6 @@ import logging
 from cryptoadvance.specterext.spectrum.bridge_rpc import BridgeRPC
 from cryptoadvance.specter.helpers import deep_update
 from cryptoadvance.specter.node import AbstractNode
-from cryptoadvance.specter.device import Device
 from cryptoadvance.specter.devices.bitcoin_core import BitcoinCore
 from cryptoadvance.specter.specter_error import BrokenCoreConnectionException
 from cryptoadvance.spectrum.spectrum import Spectrum


### PR DESCRIPTION
These are the Spectrum side changes for this PR in the Specter Desktop repo: https://github.com/cryptoadvance/specter-desktop/pull/1999

It defines an explicit `is_device_supported` method for the Spectrum node.