### PR TITLE
Bugfix: removing pytest from requirements.tx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ Flask==2.1.1
 Flask-SQLAlchemy==2.5.1
 psycopg2-binary
 requests==2.26.0
-pytest

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 
 setup(
     name="cryptoadvance.spectrum",
-    version="0.2.5",
+    version="0.3.0",
     license="MIT license",
     url="https://github.com/cryptoadvance/spectrum",
     description="Electrum adaptor for Specter-Desktop",


### PR DESCRIPTION
It's already in test_requirements.txt and it creates confusion on the specter side.