### PR TITLE
State machine for Socket Status and just more robustness

### DIFF
--- a/src/cryptoadvance/spectrum/server_endpoints/healthz.py
+++ b/src/cryptoadvance/spectrum/server_endpoints/healthz.py
@@ -19,7 +19,7 @@ def readyness():
     try:
         # Probably improvable:
         logger.info("ready?")
-        assert app.spectrum.sock is not None
+        assert app.spectrum.is_connected()
     except Exception as e:
         logger.info("no!")
         return {"message": "i am not ready"}, 500

--- a/tests/integration/elsock_test.py
+++ b/tests/integration/elsock_test.py
@@ -41,8 +41,8 @@ def test_elsock(caplog):
         f"{datetime.now()} ----------------NOW the socket was intentionally closed-----------------------------------------------------------"
     )
     logger.info(f"{datetime.now()} Let's sleep for 5 seconds")
-    time.sleep(5)
-    logger.info(f"{datetime.now()} Let's sleep for another 5 seconds")
+    time.sleep(15)
+    logger.info(f"{datetime.now()} Let's sleep for another 50 seconds")
     time.sleep(5)
     logger.info(
         f"{datetime.now()}--------------The socket connection should now work properly again-------------------------------------------------"

--- a/tests/integration/elsock_test.py
+++ b/tests/integration/elsock_test.py
@@ -42,7 +42,7 @@ def test_elsock(caplog):
     )
     logger.info(f"{datetime.now()} Let's sleep for 5 seconds")
     time.sleep(5)
-    logger.info(f"{datetime.now()} Let's sleep for 5 seconds")
+    logger.info(f"{datetime.now()} Let's sleep for another 5 seconds")
     time.sleep(5)
     logger.info(
         f"{datetime.now()}--------------The socket connection should now work properly again-------------------------------------------------"

--- a/tests/test_elsock.py
+++ b/tests/test_elsock.py
@@ -19,3 +19,54 @@ def test_elsock(config):
         )
         with pytest.raises(ElSockTimeoutException):
             res = es.ping()
+
+
+def test_elsock_thread_status():
+    es = ElectrumSocket(host="notExisting", port=123, timeout=1)
+    es.running = False
+    time.sleep(2)
+    write_mock = mock.MagicMock()
+    write_mock.is_alive.return_value = False
+    recv_mock = mock.MagicMock()
+    recv_mock.is_alive.return_value = False
+    ping_mock = mock.MagicMock()
+    ping_mock.is_alive.return_value = False
+    notify_mock = mock.MagicMock()
+    notify_mock.is_alive.return_value = False
+    es._write_thread = write_mock
+    es._recv_thread = recv_mock
+    es._ping_thread = ping_mock
+    es._notify_thread = notify_mock
+    es.thread_status
+    assert es.thread_status["write"] == False
+    assert es.thread_status["recv"] == False
+    assert es.thread_status["ping"] == False
+    assert es.thread_status["notify"] == False
+    assert es.thread_status["any_alive"] == False
+    assert es.thread_status["not_any_alive"] == True
+    assert es.thread_status["all_alive"] == False
+    assert es.thread_status["not_all_alive"] == True
+    assert es.thread_status["alive"] == []
+    assert es.thread_status["not_alive"] == ["recv", "write", "ping", "notify"]
+    ping_mock.reset_mock()
+    ping_mock.is_alive.return_value = True
+    assert es.thread_status["recv"] == False
+    assert es.thread_status["ping"] == True
+    assert es.thread_status["any_alive"] == True
+    assert es.thread_status["not_any_alive"] == False
+    assert es.thread_status["all_alive"] == False
+    assert es.thread_status["not_all_alive"] == True
+    assert es.thread_status["alive"] == ["ping"]
+    assert es.thread_status["not_alive"] == ["recv", "write", "notify"]
+    write_mock.reset_mock()
+    write_mock.is_alive.return_value = True
+    recv_mock.reset_mock()
+    recv_mock.is_alive.return_value = True
+    notify_mock.reset_mock()
+    notify_mock.is_alive.return_value = True
+    assert es.thread_status["any_alive"] == True
+    assert es.thread_status["not_any_alive"] == False
+    assert es.thread_status["all_alive"] == True
+    assert es.thread_status["not_all_alive"] == False
+    assert es.thread_status["alive"] == ["recv", "write", "ping", "notify"]
+    assert es.thread_status["not_alive"] == []


### PR DESCRIPTION
The ElectrumSocket did not yet properly reacted to the (un-) healthyness of the underlying socket connection. With this PR, we establish a state-machine which reacts apropriately to (hopefully) all the things which could possibly happen.

[![](https://mermaid.ink/img/pako:eNqNkrFuwzAMRH_F4BjES0cPmdKxU7dGgcFITCJIFgOZKhoY_vcqVtoihWtUk8R7PAo4DqDZEDTQCwptLZ4idvX7kwpVPrvVvqrrTaUjodhwanvWjqSI7CbtENlRaJ31_kbIObOmL8i89rflr-Ij-OA8R96nzTrPa_8ZsPjpBZY-SCehNlKROU9H7w-oXelaACYDdrCGjmKH1uSAhluXAjlTRwqafDV0xORFgQpjRtPF5AifjRWO0BzR97QGTMKv16ChkZjoC7rn_E1dMLwx_7xpMnkpmzEtyPgJFpXCuw?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNqNkrFuwzAMRH_F4BjES0cPmdKxU7dGgcFITCJIFgOZKhoY_vcqVtoihWtUk8R7PAo4DqDZEDTQCwptLZ4idvX7kwpVPrvVvqrrTaUjodhwanvWjqSI7CbtENlRaJ31_kbIObOmL8i89rflr-Ij-OA8R96nzTrPa_8ZsPjpBZY-SCehNlKROU9H7w-oXelaACYDdrCGjmKH1uSAhluXAjlTRwqafDV0xORFgQpjRtPF5AifjRWO0BzR97QGTMKv16ChkZjoC7rn_E1dMLwx_7xpMnkpmzEtyPgJFpXCuw)

The states are stored in the `ElectrumSocket.state` property. The Constructor of the `ElectrumSocket` is hardly doing more than just setting up the `_monitor_thread` which is an endless loop going through these states:
* `creating_sockets` will create the sockets and pass to `creating_threads` or to `broken_creating_sockets` if that fails
* `broken_creating_sockets` will try to create the socket and sleep for some time if that fails (and endlessly try to do that)
* `creating_threads` will create the write/recv/ping/notify threads and start them
* `execute_recreation_callback` will call that callback after setting the status to `ok`
* the `ok` state will now simply check the other thready and if one of them is no longer alive (probably the ping-thread as he will exit if ping fails for 4 times) it will transition to `broken_killing_threads`
* `broken_killing_threads` will set `self.running` to false and wait for the threads to terminate. Especially the `recv` thread might not terminate until he get internet connection (again). This might take forever. If all threads are terminated, it will transition to `creating_socket`


