### PR TITLE
pin SQLAlchemy to 2.0.30

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 embit>=0.6.1
 Flask>=2.1.1
 Flask-SQLAlchemy==2.5.1
-sqlalchemy>=1.4.42
+sqlalchemy==2.0.30
 psycopg2-binary
 requests>=2.26.0
 pysocks==1.7.1


### PR DESCRIPTION
otherwise, you get this while building the release:

```
55085 WARNING: No module named 'cryptoadvance.specter.devices.hwi.jadepy.jade_ble'
55085 WARNING: BLE scanning/connectivity will not be available
55105 INFO: Collecting subclasses of Extension in C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\Lib\site-packages\cryptoadvance\specterext...
55120 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=devhelp is_pkg=True
55122 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=electrum is_pkg=True
55272 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=exfund is_pkg=True
55281 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=faucet is_pkg=True
55286 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=liquidissuer is_pkg=True
55293 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=notifications is_pkg=True
55352 INFO: Iterating on importer=FileFinder('C:\\gitlab-runner\\builds\\8sGzsXt7\\0\\cryptoadvance\\specter-desktop\\.buildenv\\Lib\\site-packages\\cryptoadvance\\specterext') , module_name=spectrum is_pkg=True
Traceback (most recent call last):
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\util\reflection.py", line 202, in get_subclasses_for_clazz
    module = import_module(f"{module_name}.service")
  File "C:\Program Files\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'spectrum'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\Scripts\pyinstaller.exe\__main__.py", line 7, in <module>
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\__main__.py", line 178, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\__main__.py", line 59, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 842, in main
    build(specfile, distpath, workpath, clean_build)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 764, in build
    exec(code, spec_namespace)
  File "specterd.spec", line 44, in <module>
    a = Analysis(['specterd.py'],
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 319, in __init__
    self.__postinit__()
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\datastruct.py", line 173, in __postinit__
    self.assemble()
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\building\build_main.py", line 487, in assemble
    self.graph.process_post_graph_hooks(self)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\analysis.py", line 326, in process_post_graph_hooks
    module_hook.post_graph(analysis)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\imphook.py", line 404, in post_graph
    self._load_hook_module()
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\depend\imphook.py", line 367, in _load_hook_module
    self._hook_module = importlib_load_source(self.hook_module_name, self.hook_filename)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\PyInstaller\compat.py", line 620, in importlib_load_source
    return mod_loader.load_module()
  File "<frozen importlib._bootstrap_external>", line 548, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1063, in load_module
  File "<frozen importlib._bootstrap_external>", line 888, in load_module
  File "<frozen importlib._bootstrap>", line 290, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 719, in _load
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\pyinstaller\hooks\hook-cryptoadvance.specter.services.py", line 9, in <module>
    for service_dir in ExtensionManager.get_service_x_dirs("templates")
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\managers\service_manager\service_manager.py", line 438, in get_service_x_dirs
    for clazz in get_subclasses_for_clazz(Extension)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specter\util\reflection.py", line 209, in get_subclasses_for_clazz
    module = import_module(
  File "C:\Program Files\Python310\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specterext\spectrum\service.py", line 15, in <module>
    from cryptoadvance.specterext.spectrum.spectrum_node import SpectrumNode
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specterext\spectrum\spectrum_node.py", line 4, in <module>
    from cryptoadvance.specterext.spectrum.bridge_rpc import BridgeRPC
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\specterext\spectrum\bridge_rpc.py", line 15, in <module>
    from cryptoadvance.spectrum.spectrum import RPCError as SpectrumRpcError
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\spectrum\spectrum.py", line 27, in <module>
    from .db import UTXO, Descriptor, Script, Tx, TxCategory, Wallet, db
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\cryptoadvance\spectrum\db.py", line 26, in <module>
    db = SQLAlchemy(model_class=CustomModel)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\flask_sqlalchemy\__init__.py", line 758, in __init__
    _include_sqlalchemy(self, query_class)
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\flask_sqlalchemy\__init__.py", line 112, in _include_sqlalchemy
    for key in module.__all__:
  File "C:\gitlab-runner\builds\8sGzsXt7\0\cryptoadvance\specter-desktop\.buildenv\lib\site-packages\sqlalchemy\__init__.py", line 294, in __getattr__
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
AttributeError: module 'sqlalchemy' has no attribute '__all__'. Did you mean: '__file__'?
```