### PR TITLE
Fix bitcoin core 28.0 bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 embit>=0.6.1
 Flask>=2.1.1
-Flask-SQLAlchemy==2.5.1
-sqlalchemy==2.0.30
+Flask-SQLAlchemy>=3.1.0
+sqlalchemy>=2.0.36
 psycopg2-binary
 requests>=2.26.0
 pysocks==1.7.1

--- a/src/cryptoadvance/spectrum/util_specter.py
+++ b/src/cryptoadvance/spectrum/util_specter.py
@@ -295,7 +295,7 @@ class BitcoinRPC:
     def __getattr__(self, method):
         def fn(*args, **kwargs):
             r = self.multi([(method, *args)], **kwargs)[0]
-            if r["error"] is not None:
+            if r.get("error") is not None:
                 raise Exception(
                     f"Request error for method {method}{args}: {r['error']['message']}",
                     r,


### PR DESCRIPTION
Same as https://github.com/cryptoadvance/specter-desktop/pull/2480

`src/cryptoadvance/spectrum/util_specter.py` uses copy and paste code from Specter ... 🙈