### PR TITLE
Pin sqlalchemy<2.0 to fix startup crash with Flask-SQLAlchemy 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 embit>=0.6.1
 Flask>=2.1.1
 Flask-SQLAlchemy==2.5.1
-sqlalchemy==2.0.30
+sqlalchemy>=1.4.42,<2.0
 psycopg2-binary
 requests>=2.26.0
 pysocks==1.7.1


### PR DESCRIPTION
## Problem

Specter Desktop crashes on startup with:

```
AttributeError: module 'sqlalchemy' has no attribute '__all__'
```

Traceback: `flask_sqlalchemy/__init__.py:112` in `_include_sqlalchemy` → `for key in module.__all__`

## Root Cause

`Flask-SQLAlchemy==2.5.1` uses `_include_sqlalchemy()` which iterates over `sqlalchemy.__all__`. SQLAlchemy 2.0 removed `__all__`, breaking this function.

The current `requirements.txt` on master pins `sqlalchemy==2.0.30`, which is incompatible with `Flask-SQLAlchemy==2.5.1`. The released version (0.6.7) has `sqlalchemy>=1.4.42` with no upper bound, so pip can resolve to 2.x on fresh installs.

## Fix

Pin `sqlalchemy>=1.4.42,<2.0` until Flask-SQLAlchemy is upgraded to 3.x.

## Reported

Users hitting this on Raspberry Pi (RaspiBlitz) with fresh pip installs. See: raspiblitz/raspiblitz#5224 (related startup issues).