### PR TITLE
Add PyPI publish workflow (GitHub Actions)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-*
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # setuptools_scm needs full history for version
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify version matches tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(python -c "from importlib.metadata import version; print(version('cryptoadvance.spectrum'))" 2>/dev/null || \
+            python -c "import re; print(re.search(r'Version: (.+)', open('src/cryptoadvance_spectrum.egg-info/PKG-INFO').read()).group(1))" 2>/dev/null || \
+            ls dist/*.tar.gz | grep -oP '\d+\.\d+\.\d+')
+          echo "Tag version: $TAG"
+          echo "Package version: $PKG_VERSION"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Automates PyPI publishing on tag push. No more manual `twine upload`.

## How it works
- Triggers on version tags (`v*.*.*`)
- Uses **PyPI trusted publishing** (OIDC, no API tokens to manage)
- `setuptools_scm` derives the version from the git tag automatically
- Verifies the built package version matches the tag

## Setup needed after merge
Configure trusted publishing on [pypi.org](https://pypi.org/manage/project/cryptoadvance-spectrum/settings/publishing/):

1. Go to **Publishing** → **Add a new publisher**
2. Fill in:
   - Owner: `cryptoadvance`
   - Repository: `spectrum`
   - Workflow name: `pypi-publish.yml`
   - Environment: *(leave blank)*

## Release process after setup
```bash
git tag v0.7.0
git push origin v0.7.0
# → workflow builds and publishes automatically
```